### PR TITLE
Fix for bad argument count

### DIFF
--- a/sorting/srfi-132-test.sps
+++ b/sorting/srfi-132-test.sps
@@ -237,9 +237,6 @@
 	((= i end) new)
       (vector-set! new j (vector-ref vec i)))))
 
-(define (vector-copy vec)
-  (vector-portion-copy vec 0 (vector-length vec)))
-
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;
 ;;; End of Olin's code.


### PR DESCRIPTION
When running these tests on Chicken 5.2.0 I get:

```
bad argument count - received 3 but expected 1: #<procedure (vector-copy vec)>
```

Please see this issue for the full log:

https://github.com/diamond-lizard/srfi-132/issues/1

I'm not sure why ```vector-copy``` was defined in
```srfi-132-test.sps```, but removing it fixed this issue.